### PR TITLE
Check if the outputPath is valid

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const critical = require("critical");
 
 module.exports = function (config, options) {
   config.addTransform("critical-css", async function (content, outputPath) {
-    if (outputPath.endsWith(".html")) {
+    if (outputPath && outputPath.endsWith(".html")) {
       const { html } = await critical.generate({
         assetPaths: [path.dirname(outputPath)],
         base: this._config.dir.output,


### PR DESCRIPTION
Hi, thanks for this nice plugin !

I think this update would allow it to work in cases where a post have a `permakink: false` property, like in this [project of mine](https://github.com/bcalou/top-books-2020). It prevents the plugin to throw an error when `outputPath` is `false`.